### PR TITLE
[SOL66-3] Prevent replayable consent & add expiry time

### DIFF
--- a/contracts/extensions/mint/ERC1238Approval.sol
+++ b/contracts/extensions/mint/ERC1238Approval.sol
@@ -146,10 +146,15 @@ contract ERC1238Approval {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) internal view {
+    ) internal {
         ERC1238ApprovalState storage erc1238ApprovalState = ERC1238ApprovalStorage._getState();
+        // Prevent replay of signatures
+        require(!erc1238ApprovalState.hasApprovalHashBeenUsed[mintApprovalHash], "ERC1238: Approval hash already used");
 
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", erc1238ApprovalState.domainTypeHash, mintApprovalHash));
+
         require(ecrecover(digest, v, r, s) == recipient, "ERC1238: Approval verification failed");
+
+        erc1238ApprovalState.hasApprovalHashBeenUsed[mintApprovalHash] = true;
     }
 }

--- a/contracts/extensions/mint/IBadgeMintLogic.sol
+++ b/contracts/extensions/mint/IBadgeMintLogic.sol
@@ -2,6 +2,20 @@
 pragma solidity ^0.8.13;
 
 interface IBadgeMintLogic {
+    struct Batch {
+        address to;
+        uint256[] ids;
+        uint256[] amounts;
+        bytes data;
+    }
+
+    struct MintApprovalSignature {
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+        uint256 approvalExpiry;
+    }
+
     /**
      * @dev Creates `amount` tokens of token type `id`, and assigns them to the
      * Externally Owned Account (to).
@@ -20,6 +34,7 @@ interface IBadgeMintLogic {
         uint8 v,
         bytes32 r,
         bytes32 s,
+        uint256 approvalExpiry,
         string calldata uri,
         bytes calldata data
     ) external;
@@ -56,14 +71,12 @@ interface IBadgeMintLogic {
      * Emits a {MintBatch} event.
      */
     function mintBatchToEOA(
-        address to,
-        uint256[] calldata ids,
-        uint256[] calldata amounts,
+        Batch calldata batch,
         uint8 v,
         bytes32 r,
         bytes32 s,
-        string[] calldata uris,
-        bytes calldata data
+        uint256 approvalExpiry,
+        string[] calldata uris
     ) external;
 
     /**
@@ -80,13 +93,7 @@ interface IBadgeMintLogic {
      *
      * Emits a {MintBatch} event.
      */
-    function mintBatchToContract(
-        address to,
-        uint256[] calldata ids,
-        uint256[] calldata amounts,
-        string[] calldata uris,
-        bytes calldata data
-    ) external;
+    function mintBatchToContract(Batch calldata batch, string[] calldata uris) external;
 
     /**
      * @dev Mints a bundle, which can be viewed as minting several batches
@@ -103,10 +110,8 @@ interface IBadgeMintLogic {
      * Emits multiple {MintBatch} events.
      */
     function mintBundle(
-        address[] calldata to,
-        uint256[][] calldata ids,
-        uint256[][] calldata amounts,
-        string[][] calldata uris,
-        bytes[] calldata data
+        Batch[] calldata batches,
+        MintApprovalSignature[] calldata mintApprovalSignatures,
+        string[][] calldata uris
     ) external;
 }

--- a/contracts/extensions/mint/MintBaseLogic.sol
+++ b/contracts/extensions/mint/MintBaseLogic.sol
@@ -59,9 +59,12 @@ contract MintBaseLogic is ERC1238Approval, IMintBaseLogic {
         uint8 v,
         bytes32 r,
         bytes32 s,
+        uint256 approvalExpiry,
         bytes memory data
     ) internal virtual {
-        bytes32 messageHash = _getMintApprovalMessageHash(to, id, amount);
+        require(approvalExpiry >= block.timestamp, "ERC1238: invalid approval expiry time");
+
+        bytes32 messageHash = _getMintApprovalMessageHash(to, id, amount, approvalExpiry);
 
         _verifyMintingApproval(to, messageHash, v, r, s);
 
@@ -109,9 +112,12 @@ contract MintBaseLogic is ERC1238Approval, IMintBaseLogic {
         uint8 v,
         bytes32 r,
         bytes32 s,
+        uint256 approvalExpiry,
         bytes memory data
     ) internal virtual {
-        bytes32 messageHash = _getMintBatchApprovalMessageHash(to, ids, amounts);
+        require(approvalExpiry >= block.timestamp, "ERC1238: invalid approval expiry time");
+
+        bytes32 messageHash = _getMintBatchApprovalMessageHash(to, ids, amounts, approvalExpiry);
         _verifyMintingApproval(to, messageHash, v, r, s);
 
         _mintBatch(to, ids, amounts, data);

--- a/contracts/storage/ERC1238ApprovalStorage.sol
+++ b/contracts/storage/ERC1238ApprovalStorage.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 struct ERC1238ApprovalState {
     bytes32 domainTypeHash;
+    mapping(bytes32 => bool) hasApprovalHashBeenUsed;
 }
 
 library ERC1238ApprovalStorage {

--- a/src/utils/ERC1238Approval.ts
+++ b/src/utils/ERC1238Approval.ts
@@ -14,6 +14,7 @@ const MintApprovaltypes = {
     { name: "recipient", type: "address" },
     { name: "id", type: "uint256" },
     { name: "amount", type: "uint256" },
+    { name: "approvalExpiry", type: "uint256" },
   ],
 };
 const MintBatchApprovalTypes = {
@@ -21,6 +22,7 @@ const MintBatchApprovalTypes = {
     { name: "recipient", type: "address" },
     { name: "ids", type: "uint256[]" },
     { name: "amounts", type: "uint256[]" },
+    { name: "approvalExpiry", type: "uint256" },
   ],
 };
 
@@ -29,12 +31,14 @@ type MintApprovalStruct = {
   recipient: string;
   id: BigNumberish;
   amount: BigNumberish;
+  approvalExpiry: BigNumberish;
 };
 
 type MintBatchApprovalStruct = {
   recipient: string;
   ids: BigNumberish[];
   amounts: BigNumberish[];
+  approvalExpiry: BigNumberish;
 };
 
 export const getMintApprovalSignature = async ({
@@ -43,12 +47,14 @@ export const getMintApprovalSignature = async ({
   chainId,
   id,
   amount,
+  approvalExpiry,
 }: {
   signer: SignerWithAddress;
   erc1238ContractAddress: string;
   chainId: number;
   id: BigNumberish;
   amount: BigNumberish;
+  approvalExpiry: BigNumberish;
 }): Promise<Signature & { fullSignature: string }> => {
   const domain = getDomain(chainId, erc1238ContractAddress);
 
@@ -56,6 +62,7 @@ export const getMintApprovalSignature = async ({
     recipient: signer.address,
     id,
     amount,
+    approvalExpiry,
   };
 
   let sig: string;
@@ -75,22 +82,25 @@ export const getMintBatchApprovalSignature = async ({
   chainId,
   ids,
   amounts,
+  approvalExpiry,
 }: {
   signer: SignerWithAddress;
   erc1238ContractAddress: string;
   chainId: number;
   ids: BigNumberish[];
   amounts: BigNumberish[];
-}): Promise<Signature & { fullSignature: string }> => {
+  approvalExpiry: BigNumberish;
+}): Promise<Signature & { approvalExpiry: BigNumberish; fullSignature: string }> => {
   const domain = getDomain(chainId, erc1238ContractAddress);
 
   const value: MintBatchApprovalStruct = {
     recipient: signer.address,
     ids,
     amounts,
+    approvalExpiry,
   };
 
   const sig = await signer._signTypedData(domain, MintBatchApprovalTypes, value);
 
-  return { fullSignature: sig, ...ethers.utils.splitSignature(sig) };
+  return { fullSignature: sig, approvalExpiry, ...ethers.utils.splitSignature(sig) };
 };

--- a/test/badge/collection.ts
+++ b/test/badge/collection.ts
@@ -17,6 +17,8 @@ import {
 import { getMintApprovalSignature, getMintBatchApprovalSignature } from "../../src/utils/ERC1238Approval";
 import { BadgeAdditionalExtensions, BadgeBaseExtensions, baseURI, chainId, makeTestEnv } from "./badgeTestEnvSetup";
 
+const EXPIRY_TIME_OFFSET = 500;
+
 describe("Badge - Collection", function () {
   let admin: SignerWithAddress;
   let eoaRecipient1: SignerWithAddress;
@@ -31,6 +33,8 @@ describe("Badge - Collection", function () {
   let badgeBurn: BurnLogic;
   let badgeCollectionLogic: ICollectionLogic;
   let badgeIPermissionLogic: IPermissionLogic;
+
+  let approvalExpiry: BigNumber;
 
   before(async function () {
     const signers = await ethers.getSigners();
@@ -193,15 +197,18 @@ describe("Badge - Collection", function () {
         let sigForNFT2: Signature;
 
         beforeEach(async () => {
-          nftId1 = await badgeCollectionLogic.getConstructedTokenID(baseId, eoaRecipient1.address, counter_0);
+          approvalExpiry = BigNumber.from(Math.floor(Date.now() / 1000) + EXPIRY_TIME_OFFSET);
 
+          nftId1 = await badgeCollectionLogic.getConstructedTokenID(baseId, eoaRecipient1.address, counter_0);
           nftId2 = await badgeCollectionLogic.getConstructedTokenID(baseId, eoaRecipient1.address, counter_1);
+
           sigForNFT1 = await getMintApprovalSignature({
             signer: eoaRecipient1,
             erc1238ContractAddress: badge.address.toLowerCase(),
             chainId,
             id: nftId1,
             amount: NFT_AMOUNT,
+            approvalExpiry,
           });
 
           sigForNFT2 = await getMintApprovalSignature({
@@ -210,6 +217,7 @@ describe("Badge - Collection", function () {
             chainId,
             id: nftId2,
             amount: NFT_AMOUNT,
+            approvalExpiry,
           });
         });
 
@@ -221,6 +229,7 @@ describe("Badge - Collection", function () {
             sigForNFT1.v,
             sigForNFT1.r,
             sigForNFT1.s,
+            approvalExpiry,
             tokenURI,
             data,
           );
@@ -239,6 +248,7 @@ describe("Badge - Collection", function () {
             sigForNFT1.v,
             sigForNFT1.r,
             sigForNFT1.s,
+            approvalExpiry,
             tokenURI,
             data,
           );
@@ -249,6 +259,7 @@ describe("Badge - Collection", function () {
             sigForNFT2.v,
             sigForNFT2.r,
             sigForNFT2.s,
+            approvalExpiry,
             tokenURI,
             data,
           );
@@ -271,15 +282,18 @@ describe("Badge - Collection", function () {
         let sigForFT2: Signature;
 
         beforeEach(async () => {
-          ftId1 = await badgeCollectionLogic.getConstructedTokenID(baseId, eoaRecipient1.address, counter_0);
+          approvalExpiry = BigNumber.from(Math.floor(Date.now() / 1000) + EXPIRY_TIME_OFFSET);
 
+          ftId1 = await badgeCollectionLogic.getConstructedTokenID(baseId, eoaRecipient1.address, counter_0);
           ftId2 = await badgeCollectionLogic.getConstructedTokenID(baseId, eoaRecipient1.address, counter_1);
+
           sigForFT1 = await getMintApprovalSignature({
             signer: eoaRecipient1,
             erc1238ContractAddress: badge.address,
             chainId,
             id: ftId1,
             amount: FT_AMOUNT_1,
+            approvalExpiry,
           });
 
           sigForFT2 = await getMintApprovalSignature({
@@ -288,6 +302,7 @@ describe("Badge - Collection", function () {
             chainId,
             id: ftId2,
             amount: FT_AMOUNT_2,
+            approvalExpiry,
           });
         });
         it("should credit the right balance of tokens from a base id", async () => {
@@ -298,6 +313,7 @@ describe("Badge - Collection", function () {
             sigForFT1.v,
             sigForFT1.r,
             sigForFT1.s,
+            approvalExpiry,
             tokenURI,
             data,
           );
@@ -316,6 +332,7 @@ describe("Badge - Collection", function () {
             sigForFT1.v,
             sigForFT1.r,
             sigForFT1.s,
+            approvalExpiry,
             tokenURI,
             data,
           );
@@ -326,6 +343,7 @@ describe("Badge - Collection", function () {
             sigForFT2.v,
             sigForFT2.r,
             sigForFT2.s,
+            approvalExpiry,
             tokenURI,
             data,
           );
@@ -370,9 +388,14 @@ describe("Badge - Collection", function () {
 
       describe("To a contract", () => {
         it("should credit the right base ids", async () => {
-          await badgeMint
-            .connect(admin)
-            .mintBatchToContract(contractRecipient1.address, tokenBatchIds, mintBatchAmounts, tokenBatchURIs, data);
+          const batch = {
+            to: contractRecipient1.address,
+            ids: tokenBatchIds,
+            amounts: mintBatchAmounts,
+            data,
+          };
+
+          await badgeMint.connect(admin).mintBatchToContract(batch, tokenBatchURIs);
 
           const balanceOfBaseId1 = await badgeCollectionLogic.callStatic.balanceFromBaseId(
             contractRecipient1.address,
@@ -394,19 +417,26 @@ describe("Badge - Collection", function () {
         let s: string;
 
         beforeEach(async () => {
+          approvalExpiry = BigNumber.from(Math.floor(Date.now() / 1000) + EXPIRY_TIME_OFFSET);
+
           ({ v, r, s } = await getMintBatchApprovalSignature({
             signer: eoaRecipient1,
             erc1238ContractAddress: badgeMint.address,
             chainId,
             ids: tokenBatchIds,
             amounts: mintBatchAmounts,
+            approvalExpiry,
           }));
         });
 
         it("should credit the right base ids", async () => {
-          await badgeMint
-            .connect(admin)
-            .mintBatchToEOA(eoaRecipient1.address, tokenBatchIds, mintBatchAmounts, v, r, s, tokenBatchURIs, data);
+          const batch = {
+            to: eoaRecipient1.address,
+            ids: tokenBatchIds,
+            amounts: mintBatchAmounts,
+            data,
+          };
+          await badgeMint.connect(admin).mintBatchToEOA(batch, v, r, s, approvalExpiry, tokenBatchURIs);
 
           const balanceOfBaseId1 = await badgeCollectionLogic.callStatic.balanceFromBaseId(
             eoaRecipient1.address,
@@ -468,15 +498,28 @@ describe("Badge - Collection", function () {
             const burnAmount = toBn("25");
 
             const tokenId = await badgeCollectionLogic.getConstructedTokenID(baseId, eoaRecipient1.address, counter);
+            const approvalExpiry = BigNumber.from(Math.floor(Date.now() / 1000) + EXPIRY_TIME_OFFSET);
+
             const { v, r, s } = await getMintApprovalSignature({
               signer: eoaRecipient1,
               erc1238ContractAddress: badge.address.toLowerCase(),
               chainId,
               id: tokenId,
               amount: mintAmount,
+              approvalExpiry,
             });
 
-            await badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, tokenURI, data);
+            await badgeMint.mintToEOA(
+              eoaRecipient1.address,
+              tokenId,
+              mintAmount,
+              v,
+              r,
+              s,
+              approvalExpiry,
+              tokenURI,
+              data,
+            );
 
             await badgeBurn.burn(eoaRecipient1.address, tokenId, burnAmount, deleteURI);
 
@@ -524,9 +567,14 @@ describe("Badge - Collection", function () {
           });
 
           it("should properly decrease the baseId balances", async () => {
-            await badgeMint
-              .connect(admin)
-              .mintBatchToContract(contractRecipient1.address, tokenBatchIds, mintBatchAmounts, tokenBatchURIs, data);
+            const batch = {
+              to: contractRecipient1.address,
+              ids: tokenBatchIds,
+              amounts: mintBatchAmounts,
+              data,
+            };
+
+            await badgeMint.connect(admin).mintBatchToContract(batch, tokenBatchURIs);
 
             await badgeBurn
               .connect(admin)
@@ -580,17 +628,30 @@ describe("Badge - Collection", function () {
           });
 
           it("should properly decrease the baseId balances", async () => {
+            const approvalExpiry = BigNumber.from(Math.floor(Date.now() / 1000) + EXPIRY_TIME_OFFSET);
+
             const { v, r, s } = await getMintBatchApprovalSignature({
               signer: eoaRecipient1,
               erc1238ContractAddress: badgeMint.address,
               chainId,
               ids: tokenBatchIds,
               amounts: mintBatchAmounts,
+              approvalExpiry,
             });
 
-            await badgeMint
-              .connect(admin)
-              .mintBatchToEOA(eoaRecipient1.address, tokenBatchIds, mintBatchAmounts, v, r, s, tokenBatchURIs, data);
+            await badgeMint.connect(admin).mintBatchToEOA(
+              {
+                to: eoaRecipient1.address,
+                ids: tokenBatchIds,
+                amounts: mintBatchAmounts,
+                data,
+              },
+              v,
+              r,
+              s,
+              approvalExpiry,
+              tokenBatchURIs,
+            );
 
             await badgeBurn.connect(admin).burnBatch(eoaRecipient1.address, tokenBatchIds, burnBatchAmounts, deleteURI);
 

--- a/test/badge/minting.ts
+++ b/test/badge/minting.ts
@@ -9,6 +9,7 @@ import {
   Badge,
   BadgeMintLogic,
   ERC1238ReceiverMock,
+  IBadgeMintLogic,
   IBalanceGettersLogic,
   IERC1238,
   IPermissionLogic,
@@ -17,6 +18,8 @@ import {
 } from "../../src/types";
 import { getMintApprovalSignature, getMintBatchApprovalSignature } from "../../src/utils/ERC1238Approval";
 import { BadgeAdditionalExtensions, BadgeBaseExtensions, baseURI, chainId, makeTestEnv } from "./badgeTestEnvSetup";
+
+const twoDaysInSeconds = 172800;
 
 describe("Badge - Minting", function () {
   let admin: SignerWithAddress;
@@ -35,6 +38,18 @@ describe("Badge - Minting", function () {
   let badgeITokenURIGetLogic: ITokenURIGetLogic;
   let badgeITokenURISetLogic: ITokenURISetLogic;
   let badgeIPermissionLogic: IPermissionLogic;
+
+  let approvalExpiry: BigNumber;
+  const tokenURI = "tokenURI";
+  const data = "0x12345678";
+  const tokenId = toBn("11223344");
+  const mintAmount = toBn("58319");
+
+  const tokenBatchIds = [toBn("2000"), toBn("2010"), toBn("2020")];
+  const mintBatchAmounts = [toBn("5000"), toBn("10000"), toBn("42195")];
+  const tokenBatchURIs = ["", "tokenUri1", "tokenUri2"];
+  const expectedTokenBatchURIs = [baseURI, tokenBatchURIs[1], tokenBatchURIs[2]];
+  let batch: IBadgeMintLogic.BatchStruct;
 
   before(async function () {
     const signers = await ethers.getSigners();
@@ -75,16 +90,6 @@ describe("Badge - Minting", function () {
   });
 
   describe("Minting", () => {
-    const tokenURI = "tokenURI";
-    const data = "0x12345678";
-    const tokenId = toBn("11223344");
-    const mintAmount = toBn("58319");
-
-    const tokenBatchIds = [toBn("2000"), toBn("2010"), toBn("2020")];
-    const mintBatchAmounts = [toBn("5000"), toBn("10000"), toBn("42195")];
-    const tokenBatchURIs = ["", "tokenUri1", "tokenUri2"];
-    const expectedTokenBatchURIs = [baseURI, tokenBatchURIs[1], tokenBatchURIs[2]];
-
     /*
      * MINTING
      */
@@ -95,12 +100,15 @@ describe("Badge - Minting", function () {
       let s: string;
 
       beforeEach(async () => {
+        approvalExpiry = BigNumber.from(Math.floor(Date.now() / 1000) + twoDaysInSeconds);
+
         ({ v, r, s } = await getMintApprovalSignature({
           signer: eoaRecipient1,
           erc1238ContractAddress: badge.address.toLowerCase(),
           chainId,
           id: tokenId,
           amount: mintAmount,
+          approvalExpiry,
         }));
       });
 
@@ -108,18 +116,31 @@ describe("Badge - Minting", function () {
         await expect(
           badgeMint
             .connect(admin)
-            .mintToEOA(ethers.constants.AddressZero, tokenId, mintAmount, v, r, s, tokenURI, data),
+            .mintToEOA(ethers.constants.AddressZero, tokenId, mintAmount, v, r, s, approvalExpiry, tokenURI, data),
         ).to.be.revertedWith("ERC1238: Approval verification failed");
+      });
+
+      it("should revert with an expired signature", async () => {
+        // Approval expiry time in the past
+        const expiredTime = approvalExpiry.sub(twoDaysInSeconds);
+
+        await expect(
+          badgeMint
+            .connect(admin)
+            .mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, expiredTime, tokenURI, data),
+        ).to.be.revertedWith("ERC1238: invalid approval expiry time");
       });
 
       it("should revert if minter is not authorized", async () => {
         await expect(
-          badgeMint.connect(signer2).mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, tokenURI, data),
+          badgeMint
+            .connect(signer2)
+            .mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, approvalExpiry, tokenURI, data),
         ).to.be.revertedWith("Unauthorized: caller is not the controller");
       });
 
       it("should credit the amount of tokens", async () => {
-        await badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, tokenURI, data);
+        await badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, approvalExpiry, tokenURI, data);
 
         const balance = await badgeIBalance.callStatic.balanceOf(eoaRecipient1.address, tokenId);
 
@@ -130,7 +151,7 @@ describe("Badge - Minting", function () {
         const factory = await ethers.getContractFactory("BadgeCallerMock");
         const badgeCallerMock = await factory.deploy(badge.address);
 
-        await badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, tokenURI, data);
+        await badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, approvalExpiry, tokenURI, data);
 
         const balance = await badgeCallerMock.callStatic.balanceOf(eoaRecipient1.address, tokenId);
 
@@ -138,7 +159,7 @@ describe("Badge - Minting", function () {
       });
 
       it("should set the token URI", async () => {
-        await badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, tokenURI, data);
+        await badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, approvalExpiry, tokenURI, data);
 
         const URI = await badgeITokenURIGetLogic.callStatic.tokenURI(tokenId);
 
@@ -146,7 +167,7 @@ describe("Badge - Minting", function () {
       });
 
       it("should allow to set an empty token URI", async () => {
-        await badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, "", data);
+        await badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, approvalExpiry, "", data);
 
         const URI = await badgeITokenURIGetLogic.callStatic.tokenURI(2);
 
@@ -155,26 +176,30 @@ describe("Badge - Minting", function () {
 
       it("should not override the token URI if none is passed when minting again", async () => {
         // 1st mint we set the URI
-        await badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, tokenURI, data);
+        await badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, approvalExpiry, tokenURI, data);
 
         const URIAfterFirstMint = await badgeITokenURIGetLogic.callStatic.tokenURI(tokenId);
         expect(URIAfterFirstMint).to.eq(tokenURI);
 
         // 2nd mint we pass an empty URI
-        await badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, "", data);
+        await badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, approvalExpiry, "", data);
 
         const URIAfterSecondMint = await badgeITokenURIGetLogic.callStatic.tokenURI(tokenId);
         expect(URIAfterSecondMint).to.eq(tokenURI);
       });
 
       it("should emit a URI event", async () => {
-        await expect(badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, tokenURI, data))
+        await expect(
+          badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, approvalExpiry, tokenURI, data),
+        )
           .to.emit(badgeITokenURISetLogic, "URI")
           .withArgs(tokenId, tokenURI);
       });
 
       it("should emit a MintSingle event", async () => {
-        await expect(badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, tokenURI, data))
+        await expect(
+          badgeMint.mintToEOA(eoaRecipient1.address, tokenId, mintAmount, v, r, s, approvalExpiry, tokenURI, data),
+        )
           .to.emit(badgeERC1238, "MintSingle")
           .withArgs(admin.address, eoaRecipient1.address, tokenId, mintAmount);
       });
@@ -235,24 +260,34 @@ describe("Badge - Minting", function () {
           chainId,
           ids: tokenBatchIds,
           amounts: mintBatchAmounts,
+          approvalExpiry,
         }));
+
+        batch = {
+          to: eoaRecipient1.address,
+          ids: tokenBatchIds,
+          amounts: mintBatchAmounts,
+          data,
+        };
       });
 
       it("should revert with an invalid signature", async () => {
+        const batchWithWrongAddress = {
+          ...batch,
+          to: ethers.constants.AddressZero,
+        };
         await expect(
-          badgeMint
-            .connect(admin)
-            .mintBatchToEOA(
-              ethers.constants.AddressZero,
-              tokenBatchIds,
-              mintBatchAmounts,
-              v,
-              r,
-              s,
-              tokenBatchURIs,
-              data,
-            ),
+          badgeMint.connect(admin).mintBatchToEOA(batchWithWrongAddress, v, r, s, approvalExpiry, tokenBatchURIs),
         ).to.be.revertedWith("ERC1238: Approval verification failed");
+      });
+
+      it("should revert with an expired signature", async () => {
+        // Approval expiry time in the past
+        const expiredTime = approvalExpiry.sub(twoDaysInSeconds);
+
+        await expect(
+          badgeMint.connect(admin).mintBatchToEOA(batch, v, r, s, expiredTime, tokenBatchURIs),
+        ).to.be.revertedWith("ERC1238: invalid approval expiry time");
       });
 
       it("should revert if the length of inputs do not match", async () => {
@@ -262,36 +297,26 @@ describe("Badge - Minting", function () {
           chainId,
           ids: tokenBatchIds.slice(1),
           amounts: mintBatchAmounts,
+          approvalExpiry,
         }));
+        const batchWithWrongIdsLength = {
+          ...batch,
+          ids: tokenBatchIds.slice(1),
+        };
 
         await expect(
-          badgeMint
-            .connect(admin)
-            .mintBatchToEOA(
-              eoaRecipient1.address,
-              tokenBatchIds.slice(1),
-              mintBatchAmounts,
-              v,
-              r,
-              s,
-              tokenBatchURIs,
-              data,
-            ),
+          badgeMint.connect(admin).mintBatchToEOA(batchWithWrongIdsLength, v, r, s, approvalExpiry, tokenBatchURIs),
         ).to.be.revertedWith("ERC1238: ids and amounts length mismatch");
       });
 
       it("should revert if minter is not authorized", async () => {
         await expect(
-          badgeMint
-            .connect(signer2)
-            .mintBatchToEOA(eoaRecipient1.address, tokenBatchIds, mintBatchAmounts, v, r, s, tokenBatchURIs, data),
+          badgeMint.connect(signer2).mintBatchToEOA(batch, v, r, s, approvalExpiry, tokenBatchURIs),
         ).to.be.revertedWith("Unauthorized: caller is not the controller");
       });
 
       it("should credit the minted tokens", async () => {
-        await badgeMint
-          .connect(admin)
-          .mintBatchToEOA(eoaRecipient1.address, tokenBatchIds, mintBatchAmounts, v, r, s, tokenBatchURIs, data);
+        await badgeMint.connect(admin).mintBatchToEOA(batch, v, r, s, approvalExpiry, tokenBatchURIs);
 
         tokenBatchIds.forEach(async (tokenId, index) =>
           expect(await badgeIBalance.callStatic.balanceOf(eoaRecipient1.address, tokenId)).to.eq(
@@ -301,9 +326,7 @@ describe("Badge - Minting", function () {
       });
 
       it("should set the right token URIs", async () => {
-        await badgeMint
-          .connect(admin)
-          .mintBatchToEOA(eoaRecipient1.address, tokenBatchIds, mintBatchAmounts, v, r, s, tokenBatchURIs, data);
+        await badgeMint.connect(admin).mintBatchToEOA(batch, v, r, s, approvalExpiry, tokenBatchURIs);
 
         const setURIs = await Promise.all(
           tokenBatchIds.map(async tokenId => await badgeITokenURIGetLogic.callStatic.tokenURI(tokenId)),
@@ -313,9 +336,7 @@ describe("Badge - Minting", function () {
       });
 
       it("should emit URI events", async () => {
-        const tx = await badgeMint
-          .connect(admin)
-          .mintBatchToEOA(eoaRecipient1.address, tokenBatchIds, mintBatchAmounts, v, r, s, tokenBatchURIs, data);
+        const tx = await badgeMint.connect(admin).mintBatchToEOA(batch, v, r, s, approvalExpiry, tokenBatchURIs);
         const receipt = await tx.wait();
 
         // Remove the first MintBatch event and parse with the right interface
@@ -329,56 +350,51 @@ describe("Badge - Minting", function () {
       });
 
       it("should emit a MintBatch event", async () => {
-        await expect(
-          badgeMint.mintBatchToEOA(
-            eoaRecipient1.address,
-            tokenBatchIds,
-            mintBatchAmounts,
-            v,
-            r,
-            s,
-            tokenBatchURIs,
-            data,
-          ),
-        )
+        await expect(badgeMint.mintBatchToEOA(batch, v, r, s, approvalExpiry, tokenBatchURIs))
           .to.emit(badgeERC1238, "MintBatch")
           .withArgs(admin.address, eoaRecipient1.address, tokenBatchIds, mintBatchAmounts);
       });
     });
 
     describe("mintBatchToContract", () => {
+      beforeEach(async () => {
+        batch = {
+          to: contractRecipient1.address,
+          ids: tokenBatchIds,
+          amounts: mintBatchAmounts,
+          data,
+        };
+      });
+
       it("should revert if the length of inputs do not match", async () => {
+        const batchWithWrongIdsLength = {
+          ...batch,
+          ids: tokenBatchIds.slice(1),
+        };
+
         await expect(
-          badgeMint
-            .connect(admin)
-            .mintBatchToContract(
-              contractRecipient1.address,
-              tokenBatchIds.slice(1),
-              mintBatchAmounts,
-              tokenBatchURIs,
-              data,
-            ),
+          badgeMint.connect(admin).mintBatchToContract(batchWithWrongIdsLength, tokenBatchURIs),
         ).to.be.revertedWith("ERC1238: ids and amounts length mismatch");
       });
 
       it("should revert if the recipient is not a contract", async () => {
-        await expect(
-          badgeMint.mintBatchToContract(eoaRecipient1.address, tokenBatchIds, mintBatchAmounts, tokenBatchURIs, data),
-        ).to.be.revertedWith("ERC1238: Recipient is not a contract");
+        const batchWithWrongRecipientType = {
+          ...batch,
+          to: eoaRecipient1.address,
+        };
+        await expect(badgeMint.mintBatchToContract(batchWithWrongRecipientType, tokenBatchURIs)).to.be.revertedWith(
+          "ERC1238: Recipient is not a contract",
+        );
       });
 
       it("should revert if minter is not authorized", async () => {
-        await expect(
-          badgeMint
-            .connect(signer2)
-            .mintBatchToContract(contractRecipient1.address, tokenBatchIds, mintBatchAmounts, tokenBatchURIs, data),
-        ).to.be.revertedWith("Unauthorized: caller is not the controller");
+        await expect(badgeMint.connect(signer2).mintBatchToContract(batch, tokenBatchURIs)).to.be.revertedWith(
+          "Unauthorized: caller is not the controller",
+        );
       });
 
       it("should credit the minted tokens", async () => {
-        await badgeMint
-          .connect(admin)
-          .mintBatchToContract(contractRecipient1.address, tokenBatchIds, mintBatchAmounts, tokenBatchURIs, data);
+        await badgeMint.connect(admin).mintBatchToContract(batch, tokenBatchURIs);
 
         tokenBatchIds.forEach(async (tokenId, index) =>
           expect(await badgeIBalance.callStatic.balanceOf(contractRecipient1.address, tokenId)).to.eq(
@@ -388,9 +404,7 @@ describe("Badge - Minting", function () {
       });
 
       it("should set the right token URIs", async () => {
-        await badgeMint
-          .connect(admin)
-          .mintBatchToContract(contractRecipient1.address, tokenBatchIds, mintBatchAmounts, tokenBatchURIs, data);
+        await badgeMint.connect(admin).mintBatchToContract(batch, tokenBatchURIs);
 
         const setURIs = await Promise.all(
           tokenBatchIds.map(async tokenId => await badgeITokenURIGetLogic.callStatic.tokenURI(tokenId)),
@@ -400,9 +414,7 @@ describe("Badge - Minting", function () {
       });
 
       it("should emit URI events", async () => {
-        const tx = await badgeMint
-          .connect(admin)
-          .mintBatchToContract(contractRecipient1.address, tokenBatchIds, mintBatchAmounts, tokenBatchURIs, data);
+        const tx = await badgeMint.connect(admin).mintBatchToContract(batch, tokenBatchURIs);
         const receipt = await tx.wait();
 
         // Remove the first MintBatch event and parse with the right interface
@@ -416,26 +428,27 @@ describe("Badge - Minting", function () {
       });
 
       it("should emit a MintBatch event", async () => {
-        await expect(
-          badgeMint.mintBatchToContract(
-            contractRecipient1.address,
-            tokenBatchIds,
-            mintBatchAmounts,
-            tokenBatchURIs,
-            data,
-          ),
-        )
+        await expect(badgeMint.mintBatchToContract(batch, tokenBatchURIs))
           .to.emit(badgeERC1238, "MintBatch")
           .withArgs(admin.address, contractRecipient1.address, tokenBatchIds, mintBatchAmounts);
       });
     });
 
     describe("Mint Bundle", () => {
+      const approvalExpiry: BigNumber = BigNumber.from(Math.floor(Date.now() / 1000) + twoDaysInSeconds);
+
       let to: string[];
       let ids: BigNumber[][];
       let amounts: BigNumber[][];
       let uris: string[][];
       let expectedUris: string[][];
+      let batches: IBadgeMintLogic.BatchStruct[];
+      const emptyMintApprovalSignature = {
+        v: BigNumber.from(0),
+        r: ethers.constants.HashZero,
+        s: ethers.constants.HashZero,
+        approvalExpiry: BigNumber.from(0),
+      };
 
       before(() => {
         to = [eoaRecipient1.address, contractRecipient1.address, contractRecipient2.address];
@@ -443,12 +456,26 @@ describe("Badge - Minting", function () {
         amounts = [mintBatchAmounts, mintBatchAmounts.map(id => id.add(3)), mintBatchAmounts.map(id => id.add(4))];
         uris = [tokenBatchURIs, tokenBatchURIs, tokenBatchURIs];
         expectedUris = [expectedTokenBatchURIs, expectedTokenBatchURIs, expectedTokenBatchURIs];
+        batches = Array(3)
+          .fill(null)
+          .map((_, i) => ({
+            to: to[i],
+            ids: ids[i],
+            amounts: amounts[i],
+            data,
+          }));
       });
 
       it("should revert if minter is not authorized", async () => {
-        await expect(badgeMint.connect(signer2).mintBundle(to, ids, amounts, uris, [])).to.be.revertedWith(
-          "Unauthorized: caller is not the controller",
-        );
+        await expect(
+          badgeMint
+            .connect(signer2)
+            .mintBundle(
+              batches,
+              [emptyMintApprovalSignature, emptyMintApprovalSignature, emptyMintApprovalSignature],
+              uris,
+            ),
+        ).to.be.revertedWith("Unauthorized: caller is not the controller");
       });
 
       it("should mint a bundle to multiple addresses", async () => {
@@ -458,11 +485,12 @@ describe("Badge - Minting", function () {
           signer: eoaRecipient1,
           ids: ids[0],
           amounts: amounts[0],
+          approvalExpiry,
         });
 
-        const data = [signatureFromEOA1.fullSignature, [], []];
+        const signatures = [signatureFromEOA1, emptyMintApprovalSignature, emptyMintApprovalSignature];
 
-        await badgeMint.mintBundle(to, ids, amounts, uris, data);
+        await badgeMint.mintBundle(batches, signatures, uris);
 
         const balancesOfRecipient1: BigNumber[] = await badgeIBalance.callStatic.balanceOfBatch(to[0], ids[0]);
         balancesOfRecipient1.forEach((balance, j) => {
@@ -487,11 +515,12 @@ describe("Badge - Minting", function () {
           signer: eoaRecipient1,
           ids: ids[0],
           amounts: amounts[0],
+          approvalExpiry,
         });
 
-        const data = [signatureFromSigner1.fullSignature, [], []];
+        const signatures = [signatureFromSigner1, emptyMintApprovalSignature, emptyMintApprovalSignature];
 
-        await badgeMint.connect(admin).mintBundle(to, ids, amounts, uris, data);
+        await badgeMint.mintBundle(batches, signatures, uris);
 
         // Fetch the URI set for each token id as a flattened array
         const setURIs = await Promise.all(
@@ -509,11 +538,12 @@ describe("Badge - Minting", function () {
           signer: eoaRecipient1,
           ids: ids[0],
           amounts: amounts[0],
+          approvalExpiry,
         });
 
-        const data = [signatureFromSigner1.fullSignature, [], []];
+        const signatures = [signatureFromSigner1, emptyMintApprovalSignature, emptyMintApprovalSignature];
 
-        const tx = badgeMint.connect(admin).mintBundle(to, ids, amounts, uris, data);
+        const tx = await badgeMint.mintBundle(batches, signatures, uris);
 
         await expect(tx).to.emit(badgeERC1238, "MintBatch").withArgs(admin.address, to[0], ids[0], amounts[0]);
         await expect(tx).to.emit(badgeERC1238, "MintBatch").withArgs(admin.address, to[1], ids[1], amounts[1]);
@@ -527,11 +557,12 @@ describe("Badge - Minting", function () {
           signer: eoaRecipient1,
           ids: ids[0],
           amounts: amounts[0],
+          approvalExpiry,
         });
 
-        const data = [signatureFromSigner1.fullSignature, [], []];
+        const signatures = [signatureFromSigner1, emptyMintApprovalSignature, emptyMintApprovalSignature];
 
-        const tx = badgeMint.connect(admin).mintBundle(to, ids, amounts, uris, data);
+        const tx = badgeMint.connect(admin).mintBundle(batches, signatures, uris);
 
         // Skip index 0 of each batch as no URI is set
         await expect(tx).to.emit(badgeITokenURISetLogic, "URI").withArgs(ids[0][1], uris[0][1]);


### PR DESCRIPTION
- Add an expiry time to approval messages such that consent is not granted forever.
- Add a mapping to store wether a specific approval message has already been used to prevent replays.
- Refactoring by introducing new Batch and MintApprovalSignature structs because I hit the dreaded stack depth limit .