### PR TITLE
Rename BurnLogic to BadgeBurnLogic

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ It uses `PermissionStorage`, `ERC1238Storage` and `ERC1238ApprovalStorage` durin
 
 `BadgeMintLogic`: Contains the logic to mint tokens and how they can be minted. It uses `ERC1238ApprovalStorage` and `ERC1238Storage`. It has a dependency to `PermissionLogic`, `TokenURISetLogic` and `BadgeBeforeMintLogic`.
 
-`BurnLogic`: Contains the logic to burn tokens and how they can be burnt. It uses `ERC1238Storage`. It has a dependency to `PermissionLogic`, `TokenURISetLogic` and `BeforeBurnLogic`.
+`BadgeBurnLogic`: Contains the logic to burn tokens and how they can be burnt. It uses `ERC1238Storage`. It has a dependency to `PermissionLogic`, `TokenURISetLogic` and `BeforeBurnLogic`.
 
 `BadgeBeforeMintLogic`: Contains custom logic for what happens before tokens are minted. It has a dependency to the `CollectionLogic`.
 

--- a/contracts/extensions/burn/IBadgeBurnLogic.sol
+++ b/contracts/extensions/burn/IBadgeBurnLogic.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-interface IBurnLogic {
+interface IBadgeBurnLogic {
     /**
      * @dev Destroys `amount` of tokens with id `id` owned by `from` and
      * optionally deletes the associated URI if deleteURI is `true`.

--- a/contracts/mocks/ERC1238ReceiverMock.sol
+++ b/contracts/mocks/ERC1238ReceiverMock.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 
 import "../interfaces/IERC1238Receiver.sol";
 import "../utils/ERC165.sol";
-import "../../contracts/extensions/burn/IBurnLogic.sol";
+import "../../contracts/extensions/burn/IBadgeBurnLogic.sol";
 
 // This is a dummy example of a ERC1238Receiver with arbitrary rules.
 // It will reject non-transferable tokens if the token id is 0 in the case of a single token mint
@@ -48,7 +48,7 @@ contract ERC1238ReceiverMock is ERC165, IERC1238Receiver {
         uint256 amount,
         bool deleteURI
     ) external {
-        IBurnLogic(targetContract).burn(address(this), id, amount, deleteURI);
+        IBadgeBurnLogic(targetContract).burn(address(this), id, amount, deleteURI);
     }
 
     function burnBatch(
@@ -58,7 +58,7 @@ contract ERC1238ReceiverMock is ERC165, IERC1238Receiver {
         uint256[] memory amounts,
         bool deleteURI
     ) public {
-        IBurnLogic(targetContract).burnBatch(from, ids, amounts, deleteURI);
+        IBadgeBurnLogic(targetContract).burnBatch(from, ids, amounts, deleteURI);
     }
 
     function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {

--- a/scripts/deployAllExtensions.ts
+++ b/scripts/deployAllExtensions.ts
@@ -17,7 +17,7 @@ async function main() {
   const beforeMintLogic = await getDeployedContractFromArtifact("BadgeBeforeMintLogic");
   const badgeMintLogic = await getDeployedContractFromArtifact("BadgeMintLogic");
   const beforeBurnLogic = await getDeployedContractFromArtifact("BadgeBeforeBurnLogic");
-  const burnLogic = await getDeployedContractFromArtifact("BurnLogic");
+  const badgeBurnLogic = await getDeployedContractFromArtifact("BadgeBurnLogic");
   const tokenURIGetLogic = await getDeployedContractFromArtifact("TokenURIGetLogic");
   const tokenURISetLogic = await getDeployedContractFromArtifact("TokenURISetLogic");
   const collectionLogic = await getDeployedContractFromArtifact("CollectionLogic");
@@ -28,7 +28,7 @@ async function main() {
     balanceGettersLogic,
     baseURILogic,
     badgeMintLogic,
-    burnLogic,
+    badgeBurnLogic,
     beforeMintLogic,
     beforeBurnLogic,
     tokenURIGetLogic,

--- a/tasks/deploy/deployBadge.ts
+++ b/tasks/deploy/deployBadge.ts
@@ -16,7 +16,7 @@ task("deploy:badge").setAction(async function (taskArguments: TaskArguments, { e
     balanceGettersLogic: "",
     baseURILogic: "",
     badgeMintLogic: "",
-    burnLogic: "",
+    badgeBurnLogic: "",
   };
 
   // 3. Fill out the addresses of the additional extensions below

--- a/test/badge/badgeTestEnvSetup.ts
+++ b/test/badge/badgeTestEnvSetup.ts
@@ -7,9 +7,9 @@ import {
   BadgeBaseURILogic,
   BadgeBeforeBurnLogic,
   BadgeBeforeMintLogic,
+  BadgeBurnLogic,
   BadgeMintLogic,
   BalanceGettersLogic,
-  BurnLogic,
   CollectionLogic,
   ERC1238ReceiverMock,
   ExtendLogic,
@@ -24,7 +24,7 @@ export type BadgeBaseExtensions = {
   balanceGettersLogic: BalanceGettersLogic;
   baseURILogic: BadgeBaseURILogic;
   badgeMintLogic: BadgeMintLogic;
-  burnLogic: BurnLogic;
+  badgeBurnLogic: BadgeBurnLogic;
 };
 
 export type BadgeAdditionalExtensions = {
@@ -65,7 +65,7 @@ export const makeTestEnv = async (adminSigner: SignerWithAddress): Promise<TestE
   const beforeMintLogic = <BadgeBeforeMintLogic>await getDeployedContractFromArtifact("BadgeBeforeMintLogic");
   const badgeMintLogic = <BadgeMintLogic>await getDeployedContractFromArtifact("BadgeMintLogic");
   const beforeBurnLogic = <BadgeBeforeBurnLogic>await getDeployedContractFromArtifact("BadgeBeforeBurnLogic");
-  const burnLogic = <BurnLogic>await getDeployedContractFromArtifact("BurnLogic");
+  const badgeBurnLogic = <BadgeBurnLogic>await getDeployedContractFromArtifact("BadgeBurnLogic");
   const tokenURIGetLogic = <TokenURIGetLogic>await getDeployedContractFromArtifact("TokenURIGetLogic");
   const tokenURISetLogic = <TokenURISetLogic>await getDeployedContractFromArtifact("TokenURISetLogic");
   const collectionLogic = <CollectionLogic>await getDeployedContractFromArtifact("CollectionLogic");
@@ -81,7 +81,7 @@ export const makeTestEnv = async (adminSigner: SignerWithAddress): Promise<TestE
       balanceGettersLogic,
       baseURILogic,
       badgeMintLogic,
-      burnLogic,
+      badgeBurnLogic,
     },
     additionalExtensions: {
       beforeMintLogic,

--- a/test/badge/burning.ts
+++ b/test/badge/burning.ts
@@ -6,8 +6,8 @@ import type { Artifact } from "hardhat/types";
 
 import {
   Badge,
+  BadgeBurnLogic,
   BadgeMintLogic,
-  BurnLogic,
   ERC1238ReceiverMock,
   IBadgeMintLogic,
   IBalanceGettersLogic,
@@ -32,7 +32,7 @@ describe("Badge - Burning", function () {
   let badgeMint: BadgeMintLogic;
   let badgeIBurnBaseLogic: IBurnBaseLogic;
   let badgeIPermissionLogic: IPermissionLogic;
-  let badgeBurn: BurnLogic;
+  let badgeBurn: BadgeBurnLogic;
   let badgeITokenURIGetLogic: ITokenURIGetLogic;
 
   const data = "0x12345678";
@@ -83,7 +83,7 @@ describe("Badge - Burning", function () {
     badgeIBalance = await ethers.getContractAt("IBalanceGettersLogic", badge.address);
     badgeMint = <BadgeMintLogic>await ethers.getContractAt("BadgeMintLogic", badge.address);
     badgeIBurnBaseLogic = <IBurnBaseLogic>await ethers.getContractAt("IBurnBaseLogic", badge.address);
-    badgeBurn = <BurnLogic>await ethers.getContractAt("BurnLogic", badge.address);
+    badgeBurn = <BadgeBurnLogic>await ethers.getContractAt("BadgeBurnLogic", badge.address);
     badgeIPermissionLogic = <IPermissionLogic>await ethers.getContractAt("IPermissionLogic", badge.address);
     badgeITokenURIGetLogic = <ITokenURIGetLogic>await ethers.getContractAt("ITokenURIGetLogic", badge.address);
 

--- a/test/badge/collection.ts
+++ b/test/badge/collection.ts
@@ -7,8 +7,8 @@ import type { Artifact } from "hardhat/types";
 
 import {
   Badge,
+  BadgeBurnLogic,
   BadgeMintLogic,
-  BurnLogic,
   ERC1238ReceiverMock,
   IBalanceGettersLogic,
   ICollectionLogic,
@@ -30,7 +30,7 @@ describe("Badge - Collection", function () {
   let badge: Badge;
   let badgeIBalance: IBalanceGettersLogic;
   let badgeMint: BadgeMintLogic;
-  let badgeBurn: BurnLogic;
+  let badgeBurn: BadgeBurnLogic;
   let badgeCollectionLogic: ICollectionLogic;
   let badgeIPermissionLogic: IPermissionLogic;
 
@@ -63,7 +63,7 @@ describe("Badge - Collection", function () {
 
     badgeIBalance = await ethers.getContractAt("IBalanceGettersLogic", badge.address);
     badgeMint = <BadgeMintLogic>await ethers.getContractAt("BadgeMintLogic", badge.address);
-    badgeBurn = <BurnLogic>await ethers.getContractAt("BurnLogic", badge.address);
+    badgeBurn = <BadgeBurnLogic>await ethers.getContractAt("BadgeBurnLogic", badge.address);
     badgeCollectionLogic = <ICollectionLogic>await ethers.getContractAt("ICollectionLogic", badge.address);
     badgeIPermissionLogic = <IPermissionLogic>await ethers.getContractAt("IPermissionLogic", badge.address);
 


### PR DESCRIPTION
In order to stay consistent with naming contracts containing custom logic (BadgeMintLogic, BadgeBaseURILogic...) "BurnLogic" is renamed "BadgeBurnLogic".